### PR TITLE
accept CIRCLE_TOKEN instead of CIRCLE_API_KEY

### DIFF
--- a/raiselog
+++ b/raiselog
@@ -60,8 +60,12 @@ if [ -z "$RELEASE_LOG_KEY" ]; then
 fi
 
 if [ -z "$CIRCLE_API_KEY" ]; then
-   >&2 echo "CIRCLE_API_KEY was not defined. Exiting."
-   exit 1
+   if [ -n "$CIRCLE_TOKEN" ]; then
+      CIRCLE_API_KEY=$CIRCLE_TOKEN;
+   else
+      >&2 echo "CIRCLE_API_KEY was not defined. Exiting."
+      exit 1
+   fi
 fi
 
 if [ ! -z "${s}" ]; then


### PR DESCRIPTION
Most circle docs use CIRCLE_TOKEN for the env var, so this PR makes this script more idiomatic and forgiving for projects that already integrate with some other aspect of circle's APIs